### PR TITLE
Fixed fading out text and button on Tidal page

### DIFF
--- a/src/app/common.module.css
+++ b/src/app/common.module.css
@@ -36,18 +36,16 @@
 }
 
 
-.sectionBlueShadowBelow::after {
+.sectionShadowBlack::after {
   content: "";
   position: absolute;
   z-index: -10;
-  bottom: 0;
+  top: 0;
   left: 0;
 
-  height: var(--section-shadow-shift);
+  height: 100%;
   width: 100%;
   
-  background: var(--bg-blue);
-  filter: blur(12.5rem);
   box-shadow: 0 calc(var(--section-shadow-shift)) var(--section-shadow-blur-radius) #000000;
 }
 

--- a/src/app/common.module.css
+++ b/src/app/common.module.css
@@ -36,8 +36,17 @@
 }
 
 
-.sectionShadowBlack {
-  box-shadow: 0 calc(-1 * var(--section-shadow-shift)) var(--section-shadow-blur-radius) #000000;
+.sectionShadowBlack::after {
+  content: "";
+  position: absolute;
+  z-index: -10;
+  top: 0;
+  left: 0;
+
+  height: 100%;
+  width: 100%;
+  
+  box-shadow: 0 calc(var(--section-shadow-shift)) var(--section-shadow-blur-radius) #000000;
 }
 
 .sectionInsetShadowBlack {

--- a/src/app/common.module.css
+++ b/src/app/common.module.css
@@ -36,17 +36,8 @@
 }
 
 
-.sectionShadowBlack::after {
-  content: "";
-  position: absolute;
-  z-index: -10;
-  top: 0;
-  left: 0;
-
-  height: 100%;
-  width: 100%;
-  
-  box-shadow: 0 calc(var(--section-shadow-shift)) var(--section-shadow-blur-radius) #000000;
+.sectionShadowBlack {
+  box-shadow: 0 calc(-1 * var(--section-shadow-shift)) var(--section-shadow-blur-radius) #000000;
 }
 
 .sectionInsetShadowBlack {

--- a/src/app/common.module.css
+++ b/src/app/common.module.css
@@ -36,16 +36,18 @@
 }
 
 
-.sectionShadowBlack::after {
+.sectionBlueShadowBelow::after {
   content: "";
   position: absolute;
   z-index: -10;
-  top: 0;
+  bottom: 0;
   left: 0;
 
-  height: 100%;
+  height: var(--section-shadow-shift);
   width: 100%;
   
+  background: var(--bg-blue);
+  filter: blur(12.5rem);
   box-shadow: 0 calc(var(--section-shadow-shift)) var(--section-shadow-blur-radius) #000000;
 }
 

--- a/src/pages/product/index.page.tsx
+++ b/src/pages/product/index.page.tsx
@@ -154,7 +154,7 @@ function TidalPage() {
             </section>
             <section
                 style={{ backgroundImage: `url("${PNG_BACKGROUND_CIRCUIT.src}")` }}
-                className={styles.section}
+                className={cn(styles.section, 'pb-20')}
             >
                 <div
                     className={cn(
@@ -214,7 +214,7 @@ function TidalPage() {
             </section>
             <section
                 ref={demoSectionRef}
-                className={cn(styles.section, styles.sectionShadowBlack)}
+                className={cn(styles.section, styles.sectionInsetShadowBlack)}
             >
                 <div
                     className={cn(

--- a/src/pages/product/index.page.tsx
+++ b/src/pages/product/index.page.tsx
@@ -154,7 +154,7 @@ function TidalPage() {
             </section>
             <section
                 style={{ backgroundImage: `url("${PNG_BACKGROUND_CIRCUIT.src}")` }}
-                className={cn(styles.section, styles.sectionBlueShadowBelow)}
+                className={cn(styles.section, styles.sectionShadowBlack)}
             >
                 <div
                     className={cn(

--- a/src/pages/product/index.page.tsx
+++ b/src/pages/product/index.page.tsx
@@ -154,7 +154,7 @@ function TidalPage() {
             </section>
             <section
                 style={{ backgroundImage: `url("${PNG_BACKGROUND_CIRCUIT.src}")` }}
-                className={cn(styles.section, styles.sectionShadowBlack)}
+                className={cn(styles.section, styles.sectionBlueShadowBelow)}
             >
                 <div
                     className={cn(

--- a/src/pages/product/index.page.tsx
+++ b/src/pages/product/index.page.tsx
@@ -154,7 +154,7 @@ function TidalPage() {
             </section>
             <section
                 style={{ backgroundImage: `url("${PNG_BACKGROUND_CIRCUIT.src}")` }}
-                className={cn(styles.section, styles.sectionShadowBlack)}
+                className={cn(styles.section, 'pb-20')}
             >
                 <div
                     className={cn(
@@ -214,7 +214,7 @@ function TidalPage() {
             </section>
             <section
                 ref={demoSectionRef}
-                className={cn(styles.section)}
+                className={cn(styles.section, styles.sectionInsetShadowBlack)}
             >
                 <div
                     className={cn(

--- a/src/pages/product/index.page.tsx
+++ b/src/pages/product/index.page.tsx
@@ -154,7 +154,7 @@ function TidalPage() {
             </section>
             <section
                 style={{ backgroundImage: `url("${PNG_BACKGROUND_CIRCUIT.src}")` }}
-                className={cn(styles.section, 'pb-20')}
+                className={cn(styles.section, styles.sectionShadowBlack)}
             >
                 <div
                     className={cn(
@@ -214,7 +214,7 @@ function TidalPage() {
             </section>
             <section
                 ref={demoSectionRef}
-                className={cn(styles.section, styles.sectionInsetShadowBlack)}
+                className={cn(styles.section)}
             >
                 <div
                     className={cn(

--- a/src/pages/product/index.page.tsx
+++ b/src/pages/product/index.page.tsx
@@ -154,7 +154,7 @@ function TidalPage() {
             </section>
             <section
                 style={{ backgroundImage: `url("${PNG_BACKGROUND_CIRCUIT.src}")` }}
-                className={cn(styles.section, 'pb-20')}
+                className={styles.section}
             >
                 <div
                     className={cn(
@@ -214,7 +214,7 @@ function TidalPage() {
             </section>
             <section
                 ref={demoSectionRef}
-                className={cn(styles.section, styles.sectionInsetShadowBlack)}
+                className={cn(styles.section, styles.sectionShadowBlack)}
             >
                 <div
                     className={cn(

--- a/src/pages/product/index.page.tsx
+++ b/src/pages/product/index.page.tsx
@@ -154,7 +154,7 @@ function TidalPage() {
             </section>
             <section
                 style={{ backgroundImage: `url("${PNG_BACKGROUND_CIRCUIT.src}")` }}
-                className={styles.section}
+                className={cn(styles.section, 'z-20')}
             >
                 <div
                     className={cn(

--- a/src/pages/product/index.page.tsx
+++ b/src/pages/product/index.page.tsx
@@ -154,7 +154,7 @@ function TidalPage() {
             </section>
             <section
                 style={{ backgroundImage: `url("${PNG_BACKGROUND_CIRCUIT.src}")` }}
-                className={cn(styles.section, 'z-20')}
+                className={cn(styles.section, 'z-20 bg-transparent')}
             >
                 <div
                     className={cn(


### PR DESCRIPTION
# Pull Request for Website

## Description
Changed the stacking order of the section with the text and button for it to appear above the next section. Also removed unnecessary background color under the background image which was hiding the gradient. Gradient now overflows under section as expected. 

## Type of Change
Please mark the relevant option(s):
- [X] Update Feature
- [ ] Add Feature
- [ ] Delete Feature
- [ ] Add File(s)
- [ ] Delete File(s)
- [ ] Other (please specify):

## Checklist:
- [X] My code adheres to the project guidelines and best practices.
- [X] I have tested my changes and they work as expected.
- [ ] I have updated the relevant documentation (if applicable).
- [ ] I have added any necessary unit tests.
- [X] I have checked for and resolved any potential conflicts.
- [X] I have sent an update to the Discord channel regarding these changes.

## Additional Notes:
N/A