### PR TITLE
Task Completed and Fixed: Updated Contact page banner to be fixed while scrolling 

### DIFF
--- a/src/pages/support/contact/index.page.tsx
+++ b/src/pages/support/contact/index.page.tsx
@@ -18,6 +18,9 @@ import styles from '@/app/common.module.css';
 import OFFICE_GIRL_3 from '@/assets/images/office-girl-3.png';
 import PNG_HIGHLIGHTEDTIPS from '@/assets/images/contact-card-highlighted-0.png';
 
+
+
+
 type FormData = {
     isAllowedUpdate: boolean | undefined;
     firstName: string;
@@ -67,17 +70,22 @@ const ContactsPage: FC = () => {
 
     return (
         <>
-            <section className={'flex justify-center w-full'}>
+
+        
+            <section className={"relative w-full h-dvh max-h-[62.5rem] overflow-hidden"}> 
+                {/* Fixed background image */}
                 <div
-                    className={cn('h-dvh max-h-[62.5rem] w-full max-w-[120rem]', 'relative bg-cover bg-center')}
+                    className={cn('absolute inset-0 z-0 bg-cover bg-center')}
                     style={{
                         backgroundImage: `url(${OFFICE_GIRL_3.src})`,
-                        position: 'relative',
+                        backgroundAttachment: 'fixed',
                         backgroundSize: 'cover',
                         backgroundPosition: '50% top',
                     }}
                 >
-                    <div className={cn(styles.content, 'relative z-10 flex items-start justify-start')}>
+                    {/* Fixed Banner content */}
+                    <div className={cn(styles.content, 'relative z-10 flex items-start justify-start h-full')}>
+                        <div className="flex flex-col justify-center"></div>
                         <div>
                             <h1
                                 className={cn(


### PR DESCRIPTION
# Pull Request for Website

## Description

This PR fixes a rendering issue on the Contact page where the banner section's visual behavior was not consistent with other pages like About or Tidal.

I Updated the banner container to support a fixed-position background image using backgroundAttachment: 'fixed'. Then i went ahead and Used absolute inset-0 with proper z-index layering to ensure the background stays fixed while allowing the foreground content to scroll over it. This mirrors the parallax-like or fixed kind of effect seen on the About and Tidal pages, creating a consistent visual experience across the site.

## Type of Change
Please mark the relevant option(s):
- [ YES] Update Feature
- [ ] Add Feature
- [ ] Delete Feature
- [ ] Add File(s)
- [ ] Delete File(s)
- [ ] Other (please specify):

## Checklist:
- [ YES ] My code adheres to the project guidelines and best practices.
- [ YES ] I have tested my changes and they work as expected.
- [  ] I have updated the relevant documentation (if applicable).
- [  ] I have added any necessary unit tests.
- [ YES ] I have checked for and resolved any potential conflicts.
- [ YES ] I have sent an update to the Discord channel regarding these changes.

## Additional Notes:
Include any additional information that reviewers should be aware of when evaluating this PR.
