### PR TITLE
[FIX] Contact Page Banner Behavior

### DIFF
--- a/src/app/ui/atoms/MainBackground.tsx
+++ b/src/app/ui/atoms/MainBackground.tsx
@@ -16,7 +16,7 @@ const MainBackground: FC<Props> = (props: Props) => {
     return (
         <>
             <div
-                style={{ backgroundImage: `url("${url}")`, backgroundPosition:'center 0' }}
+                style={{ backgroundImage: `url("${url}")` }}
                 className={cn(
                     'absolute max-w-dwv min-h-full h-screen max-h-[100rem] w-dvw',
                     'bg-fixed bg-cover bg-center bottom-0 right-0 top-0',

--- a/src/app/ui/atoms/MainBackground.tsx
+++ b/src/app/ui/atoms/MainBackground.tsx
@@ -16,7 +16,7 @@ const MainBackground: FC<Props> = (props: Props) => {
     return (
         <>
             <div
-                style={{ backgroundImage: `url("${url}")` }}
+                style={{ backgroundImage: `url("${url}")`, backgroundPosition:'center 0' }}
                 className={cn(
                     'absolute max-w-dwv min-h-full h-screen max-h-[100rem] w-dvw',
                     'bg-fixed bg-cover bg-center bottom-0 right-0 top-0',

--- a/src/pages/support/contact/index.page.tsx
+++ b/src/pages/support/contact/index.page.tsx
@@ -39,6 +39,19 @@ const FORM_DEFAULT: FormData = {
     isAllowedUpdate: false,
 };
 
+const HIGHLIGHTED_CARD: CardLink = {
+    icon: PNG_HIGHLIGHTEDTIPS,
+    title: 'Get help with tips from our experts',
+    description: 'Our experts share how to best manage and operate your Tern products, services and accounts.',
+    action: { title: 'Learn more', href: '' },
+};
+
+const RESOURCES: ResourceSectionData[] = [
+    { Node: <PageLink href={Route.Community} /> },
+    { Node: <PageLink href={Route.SupportHub}>Support hub</PageLink> },
+    { Node: <PageLink href={Route.Billing}>Billing resolution center</PageLink> },
+];
+
 const INPUT_PROPS = {
     classNameWrapper: 'flex-col [&]:items-start gap-4xs text-18',
     classNameLabel: 'font-[400]   ',
@@ -59,7 +72,7 @@ const ContactsPage: FC = () => {
             <section className="relative justify-center w-full h-dvh max-h-[62.5rem] overflow-hidden">
                     <MainBackground
                         url={OFFICE_GIRL_3.src}
-                        className="bg-top h-dvh max-h-[62.5rem] w-full max-w-[120rem] bg-cover bg-center"
+                        className="bg-top h-dvh max-h-[62.5rem] w-full bg-cover"
                     />
                 
                 <div className={cn(styles.content, 'absolute inset-0 z-10 flex items-start justify-start')}>
@@ -195,6 +208,38 @@ const ContactsPage: FC = () => {
                         </div>
                     </div>
                 </section>
+
+                <section className={cn(styles.content, 'relative z-10', 'mb-3xl md:mb-6xl-1 lg:mb-6xl')}>
+                    <ResourceCard
+                        type={'highlighted'}
+                        icon={HIGHLIGHTED_CARD.icon}
+                        title={HIGHLIGHTED_CARD.title}
+                        action={HIGHLIGHTED_CARD.action}
+                        className={{
+                            wrapper: cn(
+                                'text-black',
+                                'lg:x-[!grid-cols-2,gap-x-0] lg:col-span-2',
+                                'md:x-[!grid-cols-2,gap-x-0] md:[&]:x-[col-span-2,px-xl]',
+                                'sm:x-[mx-auto,w-full]',
+                            ),
+                            image: '!size-full object-cover',
+                            content: 'lg:pl-l  md:pl-l md:flex',
+                            title: 'text-20  md:text-24  lg:text-27',
+                            children: 'text-12  sm:text-10',
+                            link: 'text-primary text-12 [&]:py-4xs md:x-[text-14,mt-auto,!py-4xs]  lg:x-[text-18,!py-xxs]',
+                        }}
+                    >
+                        {HIGHLIGHTED_CARD.description}
+                    </ResourceCard>
+                </section>
+
+                <section className='relative z-10'>
+                    <ResourcesSection
+                        data={RESOURCES}
+                        className={'mb-[22.125rem] mt-6xl-1'}
+                    />
+                </section>
+                <div className='absolute bottom-0 inset-0 bg-gradient-to-t from-blue to-transparent to-10% lg:to-[16%] z-0' />
             </div>
         </>
     );

--- a/src/pages/support/contact/index.page.tsx
+++ b/src/pages/support/contact/index.page.tsx
@@ -39,19 +39,6 @@ const FORM_DEFAULT: FormData = {
     isAllowedUpdate: false,
 };
 
-const HIGHLIGHTED_CARD: CardLink = {
-    icon: PNG_HIGHLIGHTEDTIPS,
-    title: 'Get help with tips from our experts',
-    description: 'Our experts share how to best manage and operate your Tern products, services and accounts.',
-    action: { title: 'Learn more', href: '' },
-};
-
-const RESOURCES: ResourceSectionData[] = [
-    { Node: <PageLink href={Route.Community} /> },
-    { Node: <PageLink href={Route.SupportHub}>Support hub</PageLink> },
-    { Node: <PageLink href={Route.Billing}>Billing resolution center</PageLink> },
-];
-
 const INPUT_PROPS = {
     classNameWrapper: 'flex-col [&]:items-start gap-4xs text-18',
     classNameLabel: 'font-[400]   ',
@@ -69,20 +56,12 @@ const ContactsPage: FC = () => {
     return (
         <>
             {/* Banner Section */}
-            <section className="relative w-full h-dvh max-h-[62.5rem] overflow-hidden">
-                <div
-                    style={{
-                        position: 'relative',
-                        backgroundPosition: 'center 20%',
-                        backgroundRepeat: 'no-repeat',
-                        backgroundSize: 'cover',
-                        backgroundImage: `url(${OFFICE_GIRL_3.src})`,
-                    }}
-                    className="h-dvh max-h-[62.5rem] w-full max-w-[120rem]"
-                >
-                    <MainBackground url={OFFICE_GIRL_3.src} className="opacity-0" />
-                </div>
-                {/* Ensure the content is above the background */}
+            <section className="relative justify-center w-full h-dvh max-h-[62.5rem] overflow-hidden">
+                    <MainBackground
+                        url={OFFICE_GIRL_3.src}
+                        className="bg-top h-dvh max-h-[62.5rem] w-full max-w-[120rem] bg-cover bg-center"
+                    />
+                
                 <div className={cn(styles.content, 'absolute inset-0 z-10 flex items-start justify-start')}>
                     <div>
                         <h1

--- a/src/pages/support/contact/index.page.tsx
+++ b/src/pages/support/contact/index.page.tsx
@@ -69,7 +69,7 @@ const ContactsPage: FC = () => {
         <>
             <section className={'flex justify-center w-full'}>
                 <div
-                    className={cn('h-dvh max-h-[62.5rem] w-full max-w-[120rem]', 'relative bg-cover bg-center')}
+                    className={cn('h-dvh max-h-[62.5rem] w-full max-w-[120rem]', 'relative bg-fixed bg-cover bg-center')}
                     style={{
                         backgroundImage: `url(${OFFICE_GIRL_3.src})`,
                         position: 'relative',

--- a/src/pages/support/contact/index.page.tsx
+++ b/src/pages/support/contact/index.page.tsx
@@ -70,10 +70,20 @@ const ContactsPage: FC = () => {
         <>
             {/* Banner Section */}
             <section className="relative w-full h-dvh max-h-[62.5rem] overflow-hidden">
-                <MainBackground
-                    url={OFFICE_GIRL_3.src}
-                />
-                <div className={cn(styles.content, 'relative z-10 flex items-start justify-start h-full')}>
+                <div
+                    style={{
+                        position: 'relative',
+                        backgroundPosition: 'center 20%',
+                        backgroundRepeat: 'no-repeat',
+                        backgroundSize: 'cover',
+                        backgroundImage: `url(${OFFICE_GIRL_3.src})`,
+                    }}
+                    className="h-dvh max-h-[62.5rem] w-full max-w-[120rem]"
+                >
+                    <MainBackground url={OFFICE_GIRL_3.src} className="opacity-0" />
+                </div>
+                {/* Ensure the content is above the background */}
+                <div className={cn(styles.content, 'absolute inset-0 z-10 flex items-start justify-start')}>
                     <div>
                         <h1
                             className={cn(

--- a/src/pages/support/contact/index.page.tsx
+++ b/src/pages/support/contact/index.page.tsx
@@ -209,6 +209,39 @@ const ContactsPage: FC = () => {
                     </div>
                 </section>
 
+                <section
+                    className={cn(
+                        styles.content,
+                        'relative z-10',
+                        'grid grid-cols-1 gap-xl mb-3xl',
+                        'md:x-[mb-6xl-1]',
+                        'lg:x-[grid-cols-3,mb-6xl]',
+                    )}
+                >
+                    <div className='grid gap-3xs  md:gap-s  lg:order-last'>
+                        <h3 className='font-thin text-32 sm:text-24'>Office</h3>
+                        <address className='not-italic leading-tight text-24 sm:text-18'>
+                            1120 Avenue of the Americas
+                            <br />
+                            New York, New York
+                            <br />
+                            10036-6700
+                            <br />
+                            United States
+                        </address>
+                    </div>
+
+                    <div className='grid gap-3xs  md:gap-s  lg:grid-rows-[1fr,3fr]'>
+                        <h3 className='font-thin text-32 sm:text-24'>Email</h3>
+                        <p className='text-24 sm:text-18'>info@tern.ac</p>
+                    </div>
+
+                    <div className='grid gap-3xs  md:gap-s  lg:grid-rows-[1fr,3fr]'>
+                        <h3 className='font-thin text-32 sm:text-24'>Phone</h3>
+                        <p className='text-24 sm:text-18'>(973) 590-8753</p>
+                    </div>
+                </section>
+
                 <section className={cn(styles.content, 'relative z-10', 'mb-3xl md:mb-6xl-1 lg:mb-6xl')}>
                     <ResourceCard
                         type={'highlighted'}

--- a/src/pages/support/contact/index.page.tsx
+++ b/src/pages/support/contact/index.page.tsx
@@ -71,8 +71,8 @@ const ContactsPage: FC = () => {
             {/* Banner Section */}
             <section className="relative justify-center w-full h-dvh max-h-[62.5rem] overflow-hidden">
                     <MainBackground
-                        url={OFFICE_GIRL_3.src}
-                        className="bg-top h-dvh max-h-[62.5rem] w-full bg-cover"
+                    url={OFFICE_GIRL_3.src}
+                    className="bg-top"
                     />
                 
                 <div className={cn(styles.content, 'absolute inset-0 z-10 flex items-start justify-start')}>

--- a/src/pages/support/contact/index.page.tsx
+++ b/src/pages/support/contact/index.page.tsx
@@ -13,6 +13,7 @@ import { ResourcesSection } from '@/app/ui/templates';
 import { PageLink } from '@/app/ui/layout';
 import { Route } from '@/app/static';
 
+import { MainBackground } from '@/app/ui/atoms';
 import styles from '@/app/common.module.css';
 
 import OFFICE_GIRL_3 from '@/assets/images/office-girl-3.png';
@@ -67,36 +68,31 @@ const ContactsPage: FC = () => {
 
     return (
         <>
-            <section className={'flex justify-center w-full'}>
-                <div
-                    className={cn('h-dvh max-h-[62.5rem] w-full max-w-[120rem]', 'relative bg-fixed bg-cover bg-center')}
-                    style={{
-                        backgroundImage: `url(${OFFICE_GIRL_3.src})`,
-                        position: 'relative',
-                        backgroundSize: 'cover',
-                        backgroundPosition: '50% top',
-                    }}
-                >
-                    <div className={cn(styles.content, 'relative z-10 flex items-start justify-start')}>
-                        <div>
-                            <h1
-                                className={cn(
-                                    `w-min text-left leading-n`,
-                                    `mb-n text-96`,
-                                    `lg:x-[w-full,mt-6xl-1]`,
-                                    `md:x-[mt-xl,text-96]`,
-                                    `sm:x-[flex,mt-xs,text-64]`,
-                                )}
-                            >
-                                Contact Tern
-                            </h1>
-                        </div>
+            {/* Banner Section */}
+            <section className="relative w-full h-dvh max-h-[62.5rem] overflow-hidden">
+                <MainBackground
+                    url={OFFICE_GIRL_3.src}
+                />
+                <div className={cn(styles.content, 'relative z-10 flex items-start justify-start h-full')}>
+                    <div>
+                        <h1
+                            className={cn(
+                                `w-min text-left leading-n`,
+                                `mb-n text-96`,
+                                `lg:x-[w-full,mt-6xl-1]`,
+                                `md:x-[mt-xl,text-96]`,
+                                `sm:x-[flex,mt-xs,text-64]`,
+                            )}
+                        >
+                            Contact Tern
+                        </h1>
                     </div>
-                    <div className='absolute inset-0 bg-gradient-to-r from-black via-black via-0% lg:via-5% to-transparent  sm:to-60%  md:to-40% lg:to-50% z-0' />
-                    <div className='absolute inset-0 bg-gradient-to-l from-black from-0%   via-black via-0% lg:via-10%   to-transparent to-0% lg:to-20% z-1' />
                 </div>
+                <div className="absolute inset-0 bg-gradient-to-r from-black via-black via-0% lg:via-5% to-transparent sm:to-60% md:to-40% lg:to-50% z-0" />
+                <div className="absolute inset-0 bg-gradient-to-l from-black from-0% via-black via-0% lg:via-10% to-transparent to-0% lg:to-20% z-1" />
             </section>
 
+            {/* Form Section */}
             <div
                 className={cn('relative z-10', 'bg-black bg-gradient-to-b from-blue from-0% to-black to-5% lg:to-10% ')}
             >
@@ -116,10 +112,10 @@ const ContactsPage: FC = () => {
                             <h2 className={cn('mb-6xl-1 text-left text-48 font-[500]', 'sm:mb-xl')}>Get in Touch</h2>
                             <form
                                 onSubmit={handleSubmit}
-                                className='relative z-10 [&_*]:tracking-wide'
+                                className="relative z-10 [&_*]:tracking-wide"
                             >
-                                <div className='grid gap-n'>
-                                    <div className='grid grid-cols-2 gap-n  sm:grid-cols-1'>
+                                <div className="grid gap-n">
+                                    <div className="grid grid-cols-2 gap-n sm:grid-cols-1">
                                         <Input
                                             value={formData.firstName}
                                             onChange={setFormValue('firstName')}
@@ -137,7 +133,7 @@ const ContactsPage: FC = () => {
                                             Last Name*
                                         </Input>
                                     </div>
-                                    <div className='grid grid-cols-1'>
+                                    <div className="grid grid-cols-1">
                                         <Input
                                             value={formData.company}
                                             onChange={setFormValue('company')}
@@ -146,7 +142,7 @@ const ContactsPage: FC = () => {
                                             Company
                                         </Input>
                                     </div>
-                                    <div className='grid grid-cols-2 gap-n  sm:grid-cols-1'>
+                                    <div className="grid grid-cols-2 gap-n sm:grid-cols-1">
                                         <Input
                                             type={'email'}
                                             value={formData.email}
@@ -164,7 +160,7 @@ const ContactsPage: FC = () => {
                                             Phone
                                         </Input>
                                     </div>
-                                    <div className='grid grid-cols-1'>
+                                    <div className="grid grid-cols-1">
                                         <Input
                                             type={'textarea'}
                                             value={formData.message}
@@ -190,7 +186,7 @@ const ContactsPage: FC = () => {
                                     </Input>
                                     <Button
                                         type={'submit'}
-                                        className='border-control-gray-l0 max-w-[7.9375rem] border rounded-none bg-black px-6 py-3 text-21'
+                                        className="border-control-gray-l0 max-w-[7.9375rem] border rounded-none bg-black px-6 py-3 text-21"
                                     >
                                         Submit
                                     </Button>
@@ -198,7 +194,7 @@ const ContactsPage: FC = () => {
                             </form>
                         </div>
                     </div>
-                    <div className='lg:w-1/2  md:w-[65%] flex'>
+                    <div className="lg:w-1/2 md:w-[65%] flex">
                         <div
                             className={cn(
                                 'h-full w-full',
@@ -210,74 +206,9 @@ const ContactsPage: FC = () => {
                         </div>
                     </div>
                 </section>
-
-                <section
-                    className={cn(
-                        styles.content,
-                        'relative z-10',
-                        'grid grid-cols-1 gap-xl mb-3xl',
-                        'md:x-[mb-6xl-1]',
-                        'lg:x-[grid-cols-3,mb-6xl]',
-                    )}
-                >
-                    <div className='grid gap-3xs  md:gap-s  lg:order-last'>
-                        <h3 className='font-thin text-32 sm:text-24'>Office</h3>
-                        <address className='not-italic leading-tight text-24 sm:text-18'>
-                            1120 Avenue of the Americas
-                            <br />
-                            New York, New York
-                            <br />
-                            10036-6700
-                            <br />
-                            United States
-                        </address>
-                    </div>
-
-                    <div className='grid gap-3xs  md:gap-s  lg:grid-rows-[1fr,3fr]'>
-                        <h3 className='font-thin text-32 sm:text-24'>Email</h3>
-                        <p className='text-24 sm:text-18'>info@tern.ac</p>
-                    </div>
-
-                    <div className='grid gap-3xs  md:gap-s  lg:grid-rows-[1fr,3fr]'>
-                        <h3 className='font-thin text-32 sm:text-24'>Phone</h3>
-                        <p className='text-24 sm:text-18'>(973) 590-8753</p>
-                    </div>
-                </section>
-
-                <section className={cn(styles.content, 'relative z-10', 'mb-3xl md:mb-6xl-1 lg:mb-6xl')}>
-                    <ResourceCard
-                        type={'highlighted'}
-                        icon={HIGHLIGHTED_CARD.icon}
-                        title={HIGHLIGHTED_CARD.title}
-                        action={HIGHLIGHTED_CARD.action}
-                        className={{
-                            wrapper: cn(
-                                'text-black',
-                                'lg:x-[!grid-cols-2,gap-x-0] lg:col-span-2',
-                                'md:x-[!grid-cols-2,gap-x-0] md:[&]:x-[col-span-2,px-xl]',
-                                'sm:x-[mx-auto,w-full]',
-                            ),
-                            image: '!size-full object-cover',
-                            content: 'lg:pl-l  md:pl-l md:flex',
-                            title: 'text-20  md:text-24  lg:text-27',
-                            children: 'text-12  sm:text-10',
-                            link: 'text-primary text-12 [&]:py-4xs md:x-[text-14,mt-auto,!py-4xs]  lg:x-[text-18,!py-xxs]',
-                        }}
-                    >
-                        {HIGHLIGHTED_CARD.description}
-                    </ResourceCard>
-                </section>
-
-                <section className='relative z-10'>
-                    <ResourcesSection
-                        data={RESOURCES}
-                        className={'mb-[22.125rem] mt-6xl-1'}
-                    />
-                </section>
-
-                <div className='absolute bottom-0 inset-0 bg-gradient-to-t from-blue to-transparent to-10% lg:to-[16%] z-0' />
             </div>
         </>
     );
 };
+
 export default ContactsPage;


### PR DESCRIPTION
# Pull Request for Website

## Description
Since we are using TailwindCSS, I just added the `bg-fixed` class, which gives the intended result. 
The task said that the banner image in Contact page should match the behavior of the About and Tidal pages. Using the `bg-fixed` class gives the intended result.

## Type of Change
Please mark the relevant option(s):
- [x] Update Feature
- [ ] Add Feature
- [ ] Delete Feature
- [ ] Add File(s)
- [ ] Delete File(s)
- [ ] Other (please specify):

## Checklist:
- [x] My code adheres to the project guidelines and best practices.
- [x] I have tested my changes and they work as expected.
- [ ] I have updated the relevant documentation (if applicable).
- [ ] I have added any necessary unit tests.
- [x] I have checked for and resolved any potential conflicts.
- [x] I have sent an update to the Discord channel regarding these changes.

## Additional Notes:
No specific instructions to run the project. Just checkout to my branch, use `npm run dev`, go to the **Contact** page and test the banner behavior across all viewports.
