### PR TITLE
fix contact page: set banner bg attachment to fixed

### DIFF
--- a/src/pages/support/contact/index.page.tsx
+++ b/src/pages/support/contact/index.page.tsx
@@ -71,7 +71,7 @@ const ContactsPage: FC = () => {
             <section className={cn(styles.section, styles.fullHeightSection)}>
                 <MainBackground
                     url={OFFICE_GIRL_3}
-                    className='h-dvh max-h-[62.5rem] w-full max-w-[120rem] !bg-[50%_0vh]'
+                    className='!bg-[50%_0vh]'
                 />
                 <div className={cn(styles.content, 'relative z-10 flex items-start justify-start')}>
                     <div>

--- a/src/pages/support/contact/index.page.tsx
+++ b/src/pages/support/contact/index.page.tsx
@@ -71,7 +71,7 @@ const ContactsPage: FC = () => {
             <section className={cn(styles.section, styles.fullHeightSection)}>
                 <MainBackground
                     url={OFFICE_GIRL_3}
-                    className='!bg-[50%_0vh]'
+                    className={cn('bg-top')}
                 />
                 <div className={cn(styles.content, 'relative z-10 flex items-start justify-start')}>
                     <div>

--- a/src/pages/support/contact/index.page.tsx
+++ b/src/pages/support/contact/index.page.tsx
@@ -72,7 +72,7 @@ const ContactsPage: FC = () => {
                     className={cn('h-dvh max-h-[62.5rem] w-full max-w-[120rem]', 'relative bg-cover bg-center')}
                     style={{
                         backgroundImage: `url(${OFFICE_GIRL_3.src})`,
-                        position: 'relative',
+                        backgroundAttachment: 'fixed',
                         backgroundSize: 'cover',
                         backgroundPosition: '50% top',
                     }}

--- a/src/pages/support/contact/index.page.tsx
+++ b/src/pages/support/contact/index.page.tsx
@@ -12,6 +12,7 @@ import { ResourceCard } from '@/app/ui/organisms';
 import { ResourcesSection } from '@/app/ui/templates';
 import { PageLink } from '@/app/ui/layout';
 import { Route } from '@/app/static';
+import { MainBackground } from '@/app/ui/atoms';
 
 import styles from '@/app/common.module.css';
 
@@ -67,34 +68,28 @@ const ContactsPage: FC = () => {
 
     return (
         <>
-            <section className={'flex justify-center w-full'}>
-                <div
-                    className={cn('h-dvh max-h-[62.5rem] w-full max-w-[120rem]', 'relative bg-cover bg-center')}
-                    style={{
-                        backgroundImage: `url(${OFFICE_GIRL_3.src})`,
-                        backgroundAttachment: 'fixed',
-                        backgroundSize: 'cover',
-                        backgroundPosition: '50% top',
-                    }}
-                >
-                    <div className={cn(styles.content, 'relative z-10 flex items-start justify-start')}>
-                        <div>
-                            <h1
-                                className={cn(
-                                    `w-min text-left leading-n`,
-                                    `mb-n text-96`,
-                                    `lg:x-[w-full,mt-6xl-1]`,
-                                    `md:x-[mt-xl,text-96]`,
-                                    `sm:x-[flex,mt-xs,text-64]`,
-                                )}
-                            >
-                                Contact Tern
-                            </h1>
-                        </div>
+            <section className={cn(styles.section, styles.fullHeightSection)}>
+                <MainBackground
+                    url={OFFICE_GIRL_3}
+                    className='h-dvh max-h-[62.5rem] w-full max-w-[120rem] !bg-[50%_0vh]'
+                />
+                <div className={cn(styles.content, 'relative z-10 flex items-start justify-start')}>
+                    <div>
+                        <h1
+                            className={cn(
+                                `w-min text-left leading-n`,
+                                `mb-n text-96`,
+                                `lg:x-[w-full,mt-6xl-1]`,
+                                `md:x-[mt-xl,text-96]`,
+                                `sm:x-[flex,mt-xs,text-64]`,
+                            )}
+                        >
+                            Contact Tern
+                        </h1>
                     </div>
-                    <div className='absolute inset-0 bg-gradient-to-r from-black via-black via-0% lg:via-5% to-transparent  sm:to-60%  md:to-40% lg:to-50% z-0' />
-                    <div className='absolute inset-0 bg-gradient-to-l from-black from-0%   via-black via-0% lg:via-10%   to-transparent to-0% lg:to-20% z-1' />
                 </div>
+                <div className='absolute inset-0 bg-gradient-to-r from-black via-black via-0% lg:via-5% to-transparent  sm:to-60%  md:to-40% lg:to-50% z-0' />
+                <div className='absolute inset-0 bg-gradient-to-l from-black from-0%   via-black via-0% lg:via-10%   to-transparent to-0% lg:to-20% z-1' />
             </section>
 
             <div


### PR DESCRIPTION
# Pull Request for Website

## Description
This PR updates the Contact page banner to use a fixed bg attachment. The change ensures that the banner image remains in place as the user scrolls, matching the behavior of the About and Tidal pages. This update improves visual consistency across the website.

## Type of Change
Please mark the relevant option(s):
- [x] Update Feature
- [ ] Add Feature
- [ ] Delete Feature
- [ ] Add File(s)
- [ ] Delete File(s)
- [ ] Other (please specify):

## Checklist:
- [x] My code adheres to the project guidelines and best practices.
- [x] I have tested my changes and they work as expected.
- [ ] I have updated the relevant documentation (if applicable).
- [ ] I have added any necessary unit tests.
- [x] I have checked for and resolved any potential conflicts.
- [x] I have sent an update to the Discord channel regarding these changes.

## Additional Notes:
I've updated the Contact page banner so that the background image stays fixed during scrolling, matching the About and Tidal pages. I removed the redundant inline position: 'relative' (since it's already applied via the class) and added backgroundAttachment: 'fixed' to achieve the desired behavior. Let me know if you need any further adjustments.