### PR TITLE
WB-113 fix for fade out behavior of content in Tidal page

### DIFF
--- a/src/pages/product/index.page.tsx
+++ b/src/pages/product/index.page.tsx
@@ -153,7 +153,7 @@ function TidalPage() {
                 </div>
             </section>
             <section
-                style={{ backgroundImage: `url("${PNG_BACKGROUND_CIRCUIT.src}")` }}
+                style={{ backgroundImage: `url("${PNG_BACKGROUND_CIRCUIT.src}")`, position: 'relative', zIndex: 'auto' }}
                 className={styles.section}
             >
                 <div


### PR DESCRIPTION
# Pull Request for Website

## Description
Prevent G handbook button and paragraph above it from fading out because of the fading upward effect of the section below. Solution done by changing section styles to have relative position and auto Z-index

## Type of Change
Please mark the relevant option(s):
- [X] Update Feature
- [ ] Add Feature
- [ ] Delete Feature
- [ ] Add File(s)
- [ ] Delete File(s)
- [ ] Other (please specify):

## Checklist:
- [X] My code adheres to the project guidelines and best practices.
- [X] I have tested my changes and they work as expected.
- [X] I have updated the relevant documentation (if applicable).
- [X] I have added any necessary unit tests.
- [X] I have checked for and resolved any potential conflicts.
- [X] I have sent an update to the Discord channel regarding these changes.

## Additional Notes:
None
