### PR TITLE
Fix: Made the Contact Page banner fixed to match About/Tidal pages

### DIFF
--- a/src/pages/support/contact/index.page.tsx
+++ b/src/pages/support/contact/index.page.tsx
@@ -17,6 +17,7 @@ import styles from '@/app/common.module.css';
 
 import OFFICE_GIRL_3 from '@/assets/images/office-girl-3.png';
 import PNG_HIGHLIGHTEDTIPS from '@/assets/images/contact-card-highlighted-0.png';
+import { MainBackground } from '@/app/ui/atoms';
 
 type FormData = {
     isAllowedUpdate: boolean | undefined;
@@ -67,34 +68,28 @@ const ContactsPage: FC = () => {
 
     return (
         <>
-            <section className={'flex justify-center w-full'}>
-                <div
-                    className={cn('h-dvh max-h-[62.5rem] w-full max-w-[120rem]', 'relative bg-cover bg-center')}
-                    style={{
-                        backgroundImage: `url(${OFFICE_GIRL_3.src})`,
-                        position: 'relative',
-                        backgroundSize: 'cover',
-                        backgroundPosition: '50% top',
-                    }}
-                >
-                    <div className={cn(styles.content, 'relative z-10 flex items-start justify-start')}>
-                        <div>
-                            <h1
-                                className={cn(
-                                    `w-min text-left leading-n`,
-                                    `mb-n text-96`,
-                                    `lg:x-[w-full,mt-6xl-1]`,
-                                    `md:x-[mt-xl,text-96]`,
-                                    `sm:x-[flex,mt-xs,text-64]`,
-                                )}
-                            >
-                                Contact Tern
-                            </h1>
-                        </div>
+            <section className={cn(styles.section, styles.fullHeightSection)}>
+                <MainBackground
+                    url={OFFICE_GIRL_3.src}
+                    className='bg-[center_9%]'
+                />
+                <div className={cn(styles.content, 'relative z-10 flex items-start justify-start')}>
+                    <div>
+                        <h1
+                            className={cn(
+                                `w-min text-left leading-n`,
+                                `mb-n text-96`,
+                                `lg:x-[w-full,mt-6xl-1]`,
+                                `md:x-[mt-xl,text-96]`,
+                                `sm:x-[flex,mt-xs,text-64]`,
+                            )}
+                        >
+                            Contact Tern
+                        </h1>
                     </div>
-                    <div className='absolute inset-0 bg-gradient-to-r from-black via-black via-0% lg:via-5% to-transparent  sm:to-60%  md:to-40% lg:to-50% z-0' />
-                    <div className='absolute inset-0 bg-gradient-to-l from-black from-0%   via-black via-0% lg:via-10%   to-transparent to-0% lg:to-20% z-1' />
                 </div>
+                <div className='absolute inset-0 bg-gradient-to-r from-black via-black via-0% lg:via-5% to-transparent  sm:to-60%  md:to-40% lg:to-50% z-0' />
+                <div className='absolute inset-0 bg-gradient-to-l from-black from-0%   via-black via-0% lg:via-10%   to-transparent to-0% lg:to-20% z-1' />
             </section>
 
             <div


### PR DESCRIPTION
# Pull Request for Website

## Description
I have fixed Contact page's inconsistent banner behavior by this pull request. In contrast to the About and Tidal pages, where the banner stays fixed while scrolling, the Contact page banner used to scroll with the content.
This update ensures that the Contact page banner now behaves consistently by using the MainBackground ui component with the correct CSS configuration to fix the background image during scroll. I also added tailwind utility `bg-[center_20%]` 
to avoid the background image from cutting off at the top. 
No specific issue ID provided, but corresponds to task WB-126.

## Type of Change
Please mark the relevant option(s):
- [x] Update Feature
- [ ] Add Feature
- [ ] Delete Feature
- [ ] Add File(s)
- [ ] Delete File(s)
- [ ] Other (please specify):

## Checklist:
- [x] My code adheres to the project guidelines and best practices.
- [x] I have tested my changes and they work as expected.
- [ ] I have updated the relevant documentation (if applicable). (Not applicable)
- [ ] I have added any necessary unit tests. (Not applicable)
- [x] I have checked for and resolved any potential conflicts.
- [x] I have sent an update to the Discord channel regarding these changes.

## How to test:
1. Navigate to the Contact page.
2. Observe the banner behavior as you scroll — it should now:
  - Stay fixed in place, just like on the About and Tidal pages.
  - Not scroll along with the page content.
3. Confirm the layout and text content appear correctly positioned over the banner.


## Additional Notes:
- I matched the banner behavior and styling by referencing the implementations on the About and Tidal pages.
- I have reused the ui component MainBackground to implement the task.
- If any improvements are needed in image positioning (e.g., fine-tuning background-position), I’m happy to iterate based on feedback.

Thank you for reviewing my contribution! 