### PR TITLE
Update/wb 113 fadeout task  phat dang

### DIFF
--- a/src/pages/product/index.page.tsx
+++ b/src/pages/product/index.page.tsx
@@ -154,7 +154,7 @@ function TidalPage() {
             </section>
             <section
                 style={{ backgroundImage: `url("${PNG_BACKGROUND_CIRCUIT.src}")` }}
-                className={cn(styles.content, 'relative w-full')}
+                className={cn(styles.conten, 'relative')}
             >
                 <div
                     className={cn(

--- a/src/pages/product/index.page.tsx
+++ b/src/pages/product/index.page.tsx
@@ -154,7 +154,7 @@ function TidalPage() {
             </section>
             <section
                 style={{ backgroundImage: `url("${PNG_BACKGROUND_CIRCUIT.src}")` }}
-                className={cn(styles.conten, 'relative')}
+                className={cn(styles, 'relative')}
             >
                 <div
                     className={cn(

--- a/src/pages/product/index.page.tsx
+++ b/src/pages/product/index.page.tsx
@@ -253,25 +253,28 @@ function TidalPage() {
                     </div>
                 </div>
             </section>
-            <section
-                className='relative z-10 w-full h-fit bg-cover bg-center bg-no-repeat'
-                style={{
-                    backgroundImage: `url("${PNG_BACKGROUND_CIRCUIT.src}")`,
-                }}
-            >
-                {/* Remove any overlay div here like bg-gradient-to-b from-blue/60 to-transparent */}
-
-                <div className='mx-auto grid max-w-screen-xl grid-cols-1 items-center gap-8 px-4 py-16 sm:grid-cols-2 sm:py-24 lg:grid-cols-2 lg:px-6 relative z-20'>
-                    <Image
-                        src={PNG_GIRL}
-                        className='h-auto w-full rounded-lg'
-                        alt='Turning Heads'
-                    />
-                    <div className='text-white text-16 md:text-27 lg:text-40'>
-                        <h2 className='mb-4 text-27 md:text-48 lg:text-64 font-extrabold tracking-tight'>
+            <section className={cn(styles.section, '!bg-transparent')}>
+                <div
+                    className={cn(styles.content, 'relative z-50 grid gap-x-5xl leading-n  grid-cols-2 sm:grid-cols-1')}
+                >
+                    <div className={'contents'}>
+                        <Image
+                            src={PNG_GIRL}
+                            alt={'emulator sample'}
+                            className={'m-auto w-2/3'}
+                        />
+                    </div>
+                    <div className={'sm:contents'}>
+                        <h2
+                            className={cn(
+                                'font-bold leading-n',
+                                'sm:x-[row-start-1,mb-xs,text-center]',
+                                'text-24 md:text-40 lg:text-64',
+                            )}
+                        >
                             Turning Heads
                         </h2>
-                        <p className='opacity-100 text-white'>
+                        <p className={cn('mt-xxl  sm:x-[mx-auto,mt-xs,w-2/3]', 'text-16 md:text-27 lg:text-40')}>
                             Users can write code using the Tidal software and run that code within our online emulator,
                             enabling software developers from any experience level to explore this untapped scape of
                             programming.
@@ -279,7 +282,6 @@ function TidalPage() {
                     </div>
                 </div>
             </section>
-
             <section className={styles.section}>
                 <div
                     className={cn(

--- a/src/pages/product/index.page.tsx
+++ b/src/pages/product/index.page.tsx
@@ -154,7 +154,7 @@ function TidalPage() {
             </section>
             <section
                 style={{ backgroundImage: `url("${PNG_BACKGROUND_CIRCUIT.src}")` }}
-                className={styles.section}
+                className={cn(styles.content, 'relative w-full')}
             >
                 <div
                     className={cn(


### PR DESCRIPTION
# Pull Request for Website

## Description
To fix the visibility issues, I removed the fading overlay that was affecting the text and button elements by eliminating or overriding any gradient layers responsible for the opacity. For the G Handbook button and the text above it, I ensured they were placed above any background overlays and explicitly set their opacity to 100%. Similarly, for the "Turning Heads" section, I made sure the text was not affected by any gradient fade by applying opacity-100 and text-white directly, while keeping the original blue circuit background intact without introducing additional layers.


## Type of Change
Please mark the relevant option(s):
- [X] Update Feature
- [ ] Add Feature
- [X] Delete Feature
- [ ] Add File(s)
- [ ] Delete File(s)
- [ ] Other (please specify):

## Checklist:
- [X] My code adheres to the project guidelines and best practices.
- [X] I have tested my changes and they work as expected.
- [X] I have updated the relevant documentation (if applicable).
- [ ] I have added any necessary unit tests.
- [X] I have checked for and resolved any potential conflicts.
- [X] I have sent an update to the Discord channel regarding these changes.

## Additional Notes:
Include any additional information that reviewers should be aware of when evaluating this PR.
