### PR TITLE
update: WB-126-contact-banner-scroll-behavior

### DIFF
--- a/src/pages/support/contact/index.page.tsx
+++ b/src/pages/support/contact/index.page.tsx
@@ -12,6 +12,7 @@ import { ResourceCard } from '@/app/ui/organisms';
 import { ResourcesSection } from '@/app/ui/templates';
 import { PageLink } from '@/app/ui/layout';
 import { Route } from '@/app/static';
+import { MainBackground } from '@/app/ui/atoms';
 
 import styles from '@/app/common.module.css';
 
@@ -68,14 +69,9 @@ const ContactsPage: FC = () => {
     return (
         <>
             <section className={'flex justify-center w-full'}>
+            <MainBackground url={OFFICE_GIRL_3} />
                 <div
                     className={cn('h-dvh max-h-[62.5rem] w-full max-w-[120rem]', 'relative bg-cover bg-center')}
-                    style={{
-                        backgroundImage: `url(${OFFICE_GIRL_3.src})`,
-                        position: 'relative',
-                        backgroundSize: 'cover',
-                        backgroundPosition: '50% top',
-                    }}
                 >
                     <div className={cn(styles.content, 'relative z-10 flex items-start justify-start')}>
                         <div>

--- a/src/pages/support/contact/index.page.tsx
+++ b/src/pages/support/contact/index.page.tsx
@@ -68,8 +68,9 @@ const ContactsPage: FC = () => {
 
     return (
         <>
-            <section className={'flex justify-center w-full'}>
-            <MainBackground url={OFFICE_GIRL_3} />
+            <section className={cn('flex justify-center w-full')}>
+            <MainBackground url={OFFICE_GIRL_3} 
+                className='!bg-[center_0%]'/>
                 <div
                     className={cn('h-dvh max-h-[62.5rem] w-full max-w-[120rem]', 'relative bg-cover bg-center')}
                 >


### PR DESCRIPTION
# Pull Request for Website

## Description
This PR fixes the scrolling behavior of the Contact page banner to match the behavior of the About and Tidal pages. Previously, the Contact banner scrolled with the content. Now, it remains fixed during scroll until covered by the following section, ensuring visual consistency across these pages.

## Type of Change
Please mark the relevant option(s):
- [x] Update Feature
- [ ] Add Feature
- [ ] Delete Feature
- [ ] Add File(s)
- [ ] Delete File(s)
- [ ] Other (please specify):

## Checklist:
- [x] My code adheres to the project guidelines and best practices.
- [x] I have tested my changes and they work as expected.
- [ ] I have updated the relevant documentation (if applicable).
- [ ] I have added any necessary unit tests.
- [x] I have checked for and resolved any potential conflicts.
- [x] I have sent an update to the Discord channel regarding these changes.

## Additional Notes:
To test this fix:
Navigate to the /contact page.
Scroll down and observe the banner behavior.
It should remain fixed in view (like the banners on /about and /tidal) until the next content section scrolls over it.
