### PR TITLE
Fix: G handbook button and paragraph above from fading out.

### DIFF
--- a/src/pages/product/index.page.tsx
+++ b/src/pages/product/index.page.tsx
@@ -153,7 +153,7 @@ function TidalPage() {
                 </div>
             </section>
             <section
-                style={{ backgroundImage: `url("${PNG_BACKGROUND_CIRCUIT.src}")` }}
+                style={{ backgroundImage: `url("${PNG_BACKGROUND_CIRCUIT.src}")`, zIndex: 'auto' }}
                 className={styles.section}
             >
                 <div


### PR DESCRIPTION
# Pull Request for Website

## Description
Provide a brief description of the changes made. Highlight the purpose of the update and any relevant context. If this PR addresses a specific issue, please link it here.

Added zIndex: 'auto' to the section that has g handbook and the paragraph above. Both the button and paragraph no longer fading into transparency and are now visually consistent with the rest of the page.

## Type of Change
Please mark the relevant option(s):
- [X] Update Feature
- [ ] Add Feature
- [ ] Delete Feature
- [ ] Add File(s)
- [ ] Delete File(s)
- [ ] Other (please specify):

## Checklist:
- [X] My code adheres to the project guidelines and best practices.
- [X] I have tested my changes and they work as expected.
- [ ] I have updated the relevant documentation (if applicable).
- [ ] I have added any necessary unit tests.
- [X] I have checked for and resolved any potential conflicts.
- [ ] I have sent an update to the Discord channel regarding these changes.

## Additional Notes:
Include any additional information that reviewers should be aware of when evaluating this PR.
