### PR TITLE
WB-126: Fix sticky banner behavior on Contact page

### DIFF
--- a/src/pages/support/contact/index.page.tsx
+++ b/src/pages/support/contact/index.page.tsx
@@ -77,7 +77,7 @@ const ContactsPage: FC = () => {
                         backgroundPosition: '50% top',
                     }}
                 >
-                    <div className={cn(styles.content, 'relative z-10 flex items-start justify-start')}>
+                    <div className={cn(styles.content, 'z-10 flex items-start justify-start sticky top-0')}>
                         <div>
                             <h1
                                 className={cn(


### PR DESCRIPTION
## What I did:
- Made the banner on the Contact page sticky to match the About and Tidal pages.

## How to test:
1. Go to the Contact page
2. Scroll the page
3. The banner should now stay fixed in place and content should scroll beneath it (same behavior as About and Tidal pages).

## Notes:
Let me know if any adjustments are needed!
