### PR TITLE
Fix: Contact page banner scroll behavior (WB-126)

### DIFF
--- a/src/pages/support/contact/index.page.tsx
+++ b/src/pages/support/contact/index.page.tsx
@@ -68,15 +68,29 @@ const ContactsPage: FC = () => {
     return (
         <>
             <section className={'flex justify-center w-full'}>
-                <div
-                    className={cn('h-dvh max-h-[62.5rem] w-full max-w-[120rem]', 'relative bg-cover bg-center')}
-                    style={{
-                        backgroundImage: `url(${OFFICE_GIRL_3.src})`,
-                        position: 'relative',
-                        backgroundSize: 'cover',
-                        backgroundPosition: '50% top',
-                    }}
+            {/* <div
+                className={cn('h-dvh max-h-[62.5rem] w-full max-w-[120rem]', 'relative bg-cover bg-center')}
+                style={{
+                    backgroundImage: `url(${OFFICE_GIRL_3.src})`,
+                    position: 'relative',
+                    backgroundSize: 'cover',
+                    backgroundPosition: '50% top',
+                }}
+                > */}
+            // Fixed scroll behavior for WB-126
+            <div
+                className={cn(
+                    'h-dvh max-h-[62.5rem] w-full max-w-[120rem]',
+                    'relative bg-fixed bg-cover bg-center',
+                )}
+                style={{
+                    backgroundImage: `url(${OFFICE_GIRL_3.src})`,
+                    backgroundAttachment: 'fixed',
+                    backgroundSize: 'cover',
+                    backgroundPosition: '50% top',
+                }}
                 >
+
                     <div className={cn(styles.content, 'relative z-10 flex items-start justify-start')}>
                         <div>
                             <h1


### PR DESCRIPTION
### Summary
Fixed the Contact page banner scroll behavior to match the About and Tidal pages.

### What Was Changed
- Applied `bg-fixed` and `backgroundAttachment: 'fixed'` styles to the top banner section.
- Ensured the banner remains fixed during scroll while content flows over it.
- Matches behavior with /about and /tidal for consistency.

### How to Test
1. Run `npm run dev`
2. Visit `http://localhost:3001/contact`
3. Scroll the page — the banner should stay fixed while the content scrolls over it.

### Task Reference
WB-126

cc: @ternksym
