### PR TITLE
WB-126: Fix Contact page banner to match About/Tidal

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npm run pre-commit
+npm run pre-commitnpx lint-staged

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npm run pre-commitnpx lint-staged
+npm run pre-commit

--- a/src/pages/support/contact/index.page.tsx
+++ b/src/pages/support/contact/index.page.tsx
@@ -2,6 +2,7 @@
 
 import { FC } from 'react';
 import cn from 'classnames';
+import { MainBackground } from '@/app/ui/atoms/MainBackground';
 
 import MapEmbed from './Map';
 import { useForm } from '@/app/hooks';
@@ -67,33 +68,27 @@ const ContactsPage: FC = () => {
 
     return (
         <>
-            <section className={'flex justify-center w-full'}>
-                <div
-                    className={cn('h-dvh max-h-[62.5rem] w-full max-w-[120rem]', 'relative bg-cover bg-center')}
-                    style={{
-                        backgroundImage: `url(${OFFICE_GIRL_3.src})`,
-                        position: 'relative',
-                        backgroundSize: 'cover',
-                        backgroundPosition: '50% top',
-                    }}
-                >
-                    <div className={cn(styles.content, 'relative z-10 flex items-start justify-start')}>
-                        <div>
-                            <h1
-                                className={cn(
-                                    `w-min text-left leading-n`,
-                                    `mb-n text-96`,
-                                    `lg:x-[w-full,mt-6xl-1]`,
-                                    `md:x-[mt-xl,text-96]`,
-                                    `sm:x-[flex,mt-xs,text-64]`,
-                                )}
-                            >
-                                Contact Tern
-                            </h1>
-                        </div>
+            <section className='relative isolate h-[100vh] max-h-[62.5rem] w-full overflow-hidden'>
+                <MainBackground url={OFFICE_GIRL_3} />
+
+                {/* ✅ Brighter gradient overlays */}
+                <div className='absolute inset-0 bg-gradient-to-r from-black/50 via-black/20 to-transparent z-0' />
+                <div className='absolute inset-0 bg-gradient-to-l from-black/50 via-black/20 to-transparent z-0' />
+
+                <div className={cn(styles.content, 'relative z-10 flex items-start justify-start h-full')}>
+                    <div className='self-end pb-xl'>
+                        <h1
+                            className={cn(
+                                `w-min text-left leading-n`,
+                                `mb-n text-96`,
+                                `lg:x-[w-full,mt-6xl-1]`,
+                                `md:x-[mt-xl,text-96]`,
+                                `sm:x-[flex,mt-xs,text-64]`,
+                            )}
+                        >
+                            Contact Tern
+                        </h1>
                     </div>
-                    <div className='absolute inset-0 bg-gradient-to-r from-black via-black via-0% lg:via-5% to-transparent  sm:to-60%  md:to-40% lg:to-50% z-0' />
-                    <div className='absolute inset-0 bg-gradient-to-l from-black from-0%   via-black via-0% lg:via-10%   to-transparent to-0% lg:to-20% z-1' />
                 </div>
             </section>
 

--- a/src/pages/support/contact/index.page.tsx
+++ b/src/pages/support/contact/index.page.tsx
@@ -69,27 +69,23 @@ const ContactsPage: FC = () => {
     return (
         <>
             <section className='relative isolate h-[100vh] max-h-[62.5rem] w-full overflow-hidden'>
-                <MainBackground url={OFFICE_GIRL_3} />
+              <MainBackground url={OFFICE_GIRL_3} />
 
-                {/* ✅ Brighter gradient overlays */}
-                <div className='absolute inset-0 bg-gradient-to-r from-black/50 via-black/20 to-transparent z-0' />
-                <div className='absolute inset-0 bg-gradient-to-l from-black/50 via-black/20 to-transparent z-0' />
+              <div className='absolute inset-0 bg-gradient-to-r from-black/50 via-black/20 to-transparent z-0' />
+              <div className='absolute inset-0 bg-gradient-to-l from-black/50 via-black/20 to-transparent z-0' />
 
-                <div className={cn(styles.content, 'relative z-10 flex items-start justify-start h-full')}>
-                    <div className='self-end pb-xl'>
-                        <h1
-                            className={cn(
-                                `w-min text-left leading-n`,
-                                `mb-n text-96`,
-                                `lg:x-[w-full,mt-6xl-1]`,
-                                `md:x-[mt-xl,text-96]`,
-                                `sm:x-[flex,mt-xs,text-64]`,
-                            )}
-                        >
-                            Contact Tern
-                        </h1>
-                    </div>
-                </div>
+              <div className={cn(styles.content, 'relative z-10 flex items-center justify-center h-full')}>
+                <h1
+                  className={cn(
+                    'text-96 text-center leading-n',
+                    'lg:x-[w-full,mt-6xl-1]',
+                    'md:x-[mt-xl,text-96]',
+                    'sm:x-[flex,mt-xs,text-64]',
+                  )}
+                >
+                  Contact Tern
+                </h1>
+              </div>
             </section>
 
             <div


### PR DESCRIPTION
Replaced Contact page banner with MainBackground to match scroll and layout of About/Tidal pages.

- Used MainBackground
- Adjusted layout and height
- Lightened overlay gradients for better visibility

Pre-commit hook was also fixed. Let me know if anything else is needed.